### PR TITLE
feat: v3.0.0 对齐增强——壁纸无缝循环 + 毛玻璃补全

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ __pycache__/
 *.pyo
 .DS_Store
 rust-core/target/
+# 本地大体积资源（不在 git 仓库中，构建前按 README 准备）
+resources/
+models/
+frontend/public/wallpapers/

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -27,6 +27,13 @@ const route = useRoute();
 
 const wpUrl = ref('');
 const wpEnabled = ref(false);
+const bgVideo = ref(null);
+// 动态壁纸无缝循环：原生 loop 在循环切换时有黑屏/卡顿，改为临近结尾提前 seek 到开头偏后位置（跳过首帧解码延迟与黑帧）
+function onBgTime() {
+  const v = bgVideo.value;
+  if (!v || !v.duration || !isFinite(v.duration)) return;
+  if (v.currentTime > v.duration - 0.4) v.currentTime = 0.35;
+}
 function wpFileUrl(p) {
   if (!p) return '';
   if (/^(https?:|file:|data:)/i.test(p)) return p;
@@ -171,7 +178,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <video v-if="wpEnabled && wpUrl" :key="wpUrl" class="app-wallpaper" :src="wpUrl" autoplay muted loop playsinline preload="auto"></video>
+  <video v-if="wpEnabled && wpUrl" :key="wpUrl" ref="bgVideo" class="app-wallpaper" :src="wpUrl" autoplay muted playsinline preload="auto" @timeupdate="onBgTime"></video>
   <div class="app-shell" :class="{ 'side-collapsed': !state.sidebarOpen, 'no-player': !state.playerbarOpen, 'wallpaper-on': wpEnabled && wpUrl }">
     <SideBar />
     <TopBar />

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1256,6 +1256,25 @@ input[type="checkbox"]:active, input[type="radio"]:active { transform: scale(0.8
 .playerbar select,
 .playerbar .tp-btn.toggle-on { background: rgba(255, 255, 255, 0.14); }
 
+/* 其余面板/卡片补玻璃：主题卡 / 命令面板 / 设置胶囊 / 状态框 / 插件日志 / 引导按钮 / 快捷键 */
+.thm-card,
+.cmd-foot,
+.guide-btn,
+.radio-pill,
+.state-box,
+.plg-log,
+.kbd-key {
+  background: var(--glass-bg-strong);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+}
+.cmd-item,
+.cmd-item.on {
+  background: var(--glass-bg-strong);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+
 /* ---------- PR 前端效果：自定义下拉箭头 ---------- */
 .select-input {
   appearance: none;


### PR DESCRIPTION
基于 v3.0.0（feature/vue-refactor，f7100eb）对齐，移植两项本地独有增强：

1. **壁纸无缝循环**（frontend/src/App.vue）：原生 loop 在循环切换时有黑屏/卡顿，改为临近结尾（<0.4s）预 seek 到 0.35s，跳过首帧解码延迟。
2. **毛玻璃补全**（frontend/src/styles.css）：补齐 thm-card / cmd-foot / guide-btn / radio-pill / state-box / plg-log / kbd-key / cmd-item 的玻璃拟态背景。

另补充 .gitignore 排除本地大体积资源（resources/、models/、frontend/public/wallpapers/）。

已验证：前端构建通过、主进程语法检查通过。