### PR TITLE
fix(build): add Tauri bridge stub to keep Electron frontend build working

### DIFF
--- a/frontend/src/bridge/tauri.ts
+++ b/frontend/src/bridge/tauri.ts
@@ -1,0 +1,5 @@
+// 占位实现：当前桌面构建仍以 Electron + window.fuBridge 为主。
+// Tauri 迁移未落地前，仅提供兼容空实现，避免前端构建因缺失模块失败。
+export function installTauriBridge() {
+  // 在 Tauri 环境中这里会注入等价 bridge；Electron 下不执行任何操作。
+}


### PR DESCRIPTION
## 问题
- master 分支前端 `main.ts` 引用了 `./bridge/tauri`，但仓库缺少该文件，导致前端构建失败。

## 修复
- 新增 `frontend/src/bridge/tauri.ts` 空实现桩，Electron 构建可正常完成。